### PR TITLE
implemented simple blocking transpose 

### DIFF
--- a/src/Core/TensorBLAS.cpp
+++ b/src/Core/TensorBLAS.cpp
@@ -13,13 +13,26 @@
 template<typename T>
 void transpose(T *dest, const T *src, size_t dim1, size_t dim2, T beta) {
 	// A[dim1, dim2] --> A[dim2, dim1]
-	/// simple in-place transpose
-	for (size_t j = 0; j < dim2; ++j) {
-		for (size_t i = 0; i < dim1; ++i) {
-//			dest[j + dim2 * i] = src[i + dim1 * j];
-			dest[j + dim2 * i] = beta * dest[j + dim2 * i] + src[i + dim1 * j];
-		}
-	}
+    // using simple blocking algorithm
+
+    // empirical number determining the blocking size
+    constexpr size_t stride = 6;
+
+    // pre-allocate running indices
+    size_t jj,ii,j,i;
+
+    for(jj = 0; jj < dim1; jj += stride){
+        const size_t jend = std::min(dim1, jj + stride);
+        for(ii = 0; ii < dim2; ii += stride){
+            const size_t iend = std::min(dim2, ii + stride);
+            for(j = jj; j < jend; ++j){
+                for(i = ii; i < iend; ++i){
+                    dest[i + dim2 * j] = src[j + dim1 * i];
+                }
+            }
+        }
+    }
+
 }
 
 template<typename T, int blocksize>

--- a/tests/test_TensorBLAS.cpp
+++ b/tests/test_TensorBLAS.cpp
@@ -5,6 +5,7 @@
 #include "Core/TensorBLAS.h"
 #include <gtest/gtest.h>
 #include "Core/Tensor_Extension.h"
+#include <numeric>
 
 
 using namespace std;
@@ -517,4 +518,29 @@ TEST(TensorBLAS, threeResultingIndexContraction){
 
 }
 
+TEST(TensorBLAS, blockingTranspose) {
 
+    const size_t cols = 19;
+    const size_t rows = 31;
+
+    Tensor<double> test({rows, cols});
+    // fill in test data;
+    std::iota(test.coeffs_, test.coeffs_ + test.shape().totalDimension(), 1);
+    Tensor<double> reference_result({cols, rows});
+    Tensor<double> routine_result({cols, rows});
+
+    transpose(routine_result.coeffs_, test.coeffs_, rows, cols, 0.);
+
+    // do manual transpose as reference result
+    for(size_t i = 0; i < rows; ++i){
+        for(size_t j = 0; j < cols; ++j){
+            reference_result(j,i) = test(i,j);
+        }
+    }
+
+    for(size_t i = 0; i < test.shape().totalDimension(); ++i){
+        ASSERT_DOUBLE_EQ(reference_result.coeffs_[i], routine_result.coeffs_[i]);
+    }
+
+
+}


### PR DESCRIPTION
standard primitive transpose was replaced with most simple blocking transpose routine, yielding a speedup of around 2 in test runs